### PR TITLE
rename snapps to zkapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,53 @@
-# Snapp Developer Resource Kit
+# zkApp Developer Resource Kit
 
-This repo contains all official and community-created resource related to snapp development. The resources gathered here help new beginner to intermediate level developers learn more about snapps, how to build snapps, and how to contribute to the Mina ecosystem. 
+This repo contains all official and community-created resource related to zkApp development. The resources gathered here help new beginner to intermediate level developers learn more about zkApps, how to build zkApps, and how to contribute to the Mina ecosystem.
 
-### New to snapps? Start here!
+### New to zkApps? Start here!
 
 We recommend that you:
+
 1. Read the official docs below
 2. Watch the ["Intro to SnarkyJS and Snapps with Mina"](https://bit.ly/3q1Y5wN) recording
-3. Create an example project: https://github.com/o1-labs/snapp-cli
-4. Join the [#snapp-developers](https://discord.gg/654BcVJf) channel on Discord where you can post questions, join discussions, and meet other snapp developers.
+3. Create an example project: https://github.com/o1-labs/zkapp-cli
+4. Join the [#zkapp-developers](https://discord.gg/BFnkDZ4ZTb) channel on Discord where you can post questions, join discussions, and meet other zkApp developers.
 
-# List of Snapp Resources
+# List of zkApp Resources
 
 ## Official Documentation
 
-- [Snapps docs overview](https://bit.ly/33yeba6)
-- [How snapps work](https://bit.ly/3m7PGa9)
-- [How to write a snapp](https://bit.ly/3F3l2pG)
+- [zkApps docs overview](https://bit.ly/33yeba6)
+- [How zkApp work](https://bit.ly/3m7PGa9)
+- [How to write a zkApp](https://bit.ly/3F3l2pG)
 - [SnarkyJS API reference](https://bit.ly/3e0kkxu)
 
 ## Official Videos
 
-- [Zero Knolwedge Smart Contracts, Snapps](https://www.youtube.com/watch?v=H_JQjPDwAH0)
+- [Zero Knolwedge Smart Contracts, zkApp](https://www.youtube.com/watch?v=H_JQjPDwAH0)
 
 ## Workshop, Bootcamp, and Conference Recordings
 
-- Illumninate: Genesis Summit, June 2021 - Snapp Architecture & Progress
-    - [Video Recording](https://www.youtube.com/watch?v=AolaaEFsBY4)
-- ZKHack Workshop, Dec 2021 - Intro to SnarkyJS and Snapps with Mina
-    - [Video Recording](https://bit.ly/3q1Y5wN)
-    - [Slides](https://bit.ly/3s5DuKR)
-- Snapps Bootcamp, Dec 2021 - Intro & Session #1 
-    - [Video Recording](https://bit.ly/3saqp34)
-    - [Slides](https://bit.ly/3oYTcFN)
-- Snapps Bootcamp, Dec 2021 - Session #2 & Presentations
-    - [Video Recording](https://bit.ly/3pXorQQ)
-    - Slides (coming soon)
+- Illumninate: Genesis Summit, June 2021 - zkApp Architecture & Progress
+  - [Video Recording](https://www.youtube.com/watch?v=AolaaEFsBY4)
+- ZKHack Workshop, Dec 2021 - Intro to SnarkyJS and zkApps with Mina
+  - [Video Recording](https://bit.ly/3q1Y5wN)
+  - [Slides](https://bit.ly/3s5DuKR)
+- zkApps Bootcamp, Dec 2021 - Intro & Session #1
+  - [Video Recording](https://bit.ly/3saqp34)
+  - [Slides](https://bit.ly/3oYTcFN)
+- zkApps Bootcamp, Dec 2021 - Session #2 & Presentations
+  - [Video Recording](https://bit.ly/3pXorQQ)
+  - Slides (coming soon)
 
-
-## Community built snapps 
+## Community built zkApps
 
 - [Mina Secret Exchange](https://mina.proxylabs.org/) - The secret exchange allows users to buy imaginary tokens after successfully providing the solution to a series of math problems while keeping the solution itself secure and private, not exposing it to the network.
 - [Blind Man's Bluff](https://github.com/wotomas/BlindMansBluff#build--run) - A simplified version of poker where zk-SNARKs keep the contract unaware of the actual numbers users have, yet giving it the knowledge of the game result.
-- [Snapp Hangman](https://github.com/frisitano/snapp-hangman) - With Mina's SnarkyJS API and SnarkyJS library showing their zero-knowledge capabilities, this is a snapp Hangman game utilizing zk-SNARKs to keep the secret word and random input private.
+- [Snapp Hangman](https://github.com/frisitano/snapp-hangman) - With Mina's SnarkyJS API and SnarkyJS library showing their zero-knowledge capabilities, this is a zkApp Hangman game utilizing zk-SNARKs to keep the secret word and random input private.
 
 ### Contribute to this kit!
 
 If you notice a missing resource or want to create your own resource, feel free to add to this list by creating a pull request!
 
-If you want to share your work and build a snapp, add it here to the community built snapp directory or check out other snapps at [Snapps For Mina](https://snappsformina.com): https://snappsformina.com/submit-a-snapp. 
+If you want to share your work and build a snapp, add it here to the community built zkApp directory or check out other snapps at [zkApps For Mina](https://zkAppsformina.com): https://zkappsformina.com/submit-a-zkapp.
 
 If you have feedback or ideas, post it here on [Mina Research](https://forums.minaprotocol.com/)


### PR DESCRIPTION
Renames Snapps to zkApps and adjusts some of the old links to other resources 

note: line 19 and 20 are broken links, couldn't fix them myself 