### PR TITLE
add references to SDK components

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repo contains all official and community-created resource related to zkApp development. The resources gathered here help new beginner to intermediate level developers learn more about zkApps, how to build zkApps, and how to contribute to the Mina ecosystem.
 
+##zkApp SDK components:
+
+1. [SnarkyJS](https://github.com/o1-labs/snarkyjs)
+2. [zkApp-CLI](https://github.com/o1-labs/zkapp-cli)
+
+Note: these are still undergoing active developments, but they are mostly feature ready for you to try your hands on today! 
+
 ### New to zkApps? Start here!
 
 We recommend that you:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains all official and community-created resource related to zkApp development. The resources gathered here help new beginner to intermediate level developers learn more about zkApps, how to build zkApps, and how to contribute to the Mina ecosystem.
 
-##zkApp SDK components:
+## zkApp SDK components:
 
 1. [SnarkyJS](https://github.com/o1-labs/snarkyjs)
 2. [zkApp-CLI](https://github.com/o1-labs/zkapp-cli)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repo contains all official and community-created resource related to zkApp development. The resources gathered here help new beginner to intermediate level developers learn more about zkApps, how to build zkApps, and how to contribute to the Mina ecosystem.
 
-## zkApp SDK components:
+### zkApp SDK components:
 
 1. [SnarkyJS](https://github.com/o1-labs/snarkyjs)
 2. [zkApp-CLI](https://github.com/o1-labs/zkapp-cli)


### PR DESCRIPTION
I've seen multiple people waiting for the SDK to be released, presumably referring to the SDK descriptions in the roadmaps. However, the current resources kit make no explicit references to the fact that it includes the CLI interface and SnarkyJS, and this could be confusing to new devs coming in. This PR tries to fix it. 